### PR TITLE
modules: replace registration-agent with onboarding-agent

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -688,17 +688,17 @@
         ]
       },
       "locked": {
-        "lastModified": 1741599980,
-        "narHash": "sha256-JnjM2e33l4pMgGM4crUXosmYtRxaaiQ60ZfT8HWDDq4=",
+        "lastModified": 1742991541,
+        "narHash": "sha256-nl5R7gu3nz/hiWyPAlcEl0bUciprAat7Ouje4saV18o=",
         "ref": "refs/heads/main",
-        "rev": "3ec9cd1b6c912aca8b9367fd2a18106769b8e2c4",
-        "revCount": 125,
+        "rev": "acc62c9e480cd32b451fb3365d19e78f55b1a0b9",
+        "revCount": 357,
         "type": "git",
-        "url": "ssh://git@github.com/tiiuae/registration-agent-laptop"
+        "url": "ssh://git@github.com/tiiuae/onboarding-agent"
       },
       "original": {
         "type": "git",
-        "url": "ssh://git@github.com/tiiuae/registration-agent-laptop"
+        "url": "ssh://git@github.com/tiiuae/onboarding-agent"
       }
     },
     "root": {

--- a/flake.nix
+++ b/flake.nix
@@ -40,7 +40,7 @@
     };
 
     registration-agent = {
-      url = "git+ssh://git@github.com/tiiuae/registration-agent-laptop";
+      url = "git+ssh://git@github.com/tiiuae/onboarding-agent";
       inputs = {
         nixpkgs.follows = "nixpkgs";
         flake-utils.follows = "ghaf/flake-utils";

--- a/modules/fmo/flake-module.nix
+++ b/modules/fmo/flake-module.nix
@@ -7,7 +7,7 @@
       ./fmo-firewall
       ./fmo-certs-distribution-host
       ./fmo-dci-passthrough
-      ./registration-agent-laptop
+      ./onboarding-agent
       ./fmo-nats-server
       ./fmo-update-hostname
       ./fmo-update-ipaddress

--- a/modules/microvm/docker/config.nix
+++ b/modules/microvm/docker/config.nix
@@ -31,7 +31,7 @@ in
   imports = [
     ../../fmo/dci-service
     ../../fmo/fmo-dci-passthrough
-    ../../fmo/registration-agent-laptop
+    ../../fmo/onboarding-agent
     ../../fmo/fmo-update-hostname
   ];
 
@@ -164,7 +164,7 @@ in
       };
 
       # Setup service for registration agent
-      registration-agent-laptop = {
+      onboarding-agent = {
         enable = true;
         certs_path = "/var/lib/fogdata/certs";
         config_path = "/var/lib/fogdata";

--- a/packages/fmo-registration/default.nix
+++ b/packages/fmo-registration/default.nix
@@ -106,7 +106,7 @@ writeShellApplication {
       [yY][eE][sS] | [yY])
         cat $IP_FILE > /var/lib/fogdata/ip-address
         cat $HOSTNAME_FILE > /var/lib/fogdata/hostname
-        /run/current-system/sw/bin/registration-agent-laptop
+        /run/current-system/sw/bin/onboarding-agent
       ;;
       *)
       ;;


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

Replace the registration-agent-laptop module, responsible for provisioning and registering the device into the fleet management system, with the unified onboarding-agent module.

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [X] Summary of the proposed changes in the PR description
- [X] More detailed description in the commit message(s)
- [X] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [ ] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Laptop`x86_64`
- [X] Author has run `nix flake check` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf-fmo-laptop/actions)
- [] Author has added reviewers and removed PR draft status
- [X] Change requires full re-installation
- [ ] Change can be updated with `nixos-rebuild ... switch`

<!-- Additional description of omitted [ ] items if not obvious. -->

## Instructions for Testing

- [X] List all targets that this applies to:
  - [X] x86_64
- [X] Is this a new feature
  - [X] List the test steps to verify:
    - Follow the same testing process as with registration-agent, as the end result should be identical.
- [ ] If it is an improvement how does it impact existing functionality?
