### PR TITLE
feat(onboarding): encrypt secrets during registration

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -665,11 +665,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743672769,
-        "narHash": "sha256-xj6RyydarDZSlNSpuBiuBS9lNI3pw69TB3Toc/KLm1U=",
+        "lastModified": 1743750435,
+        "narHash": "sha256-9GZza5trffpV2QKON1gmEKX4J8kUhyi4GNXCjPOe/gw=",
         "ref": "refs/heads/main",
-        "rev": "0b38cf57dded4e603d21a0870fb78c7ed356a7d9",
-        "revCount": 372,
+        "rev": "fe6f48d1ce46a474944e1cea2cc14a90285c949b",
+        "revCount": 375,
         "type": "git",
         "url": "ssh://git@github.com/tiiuae/onboarding-agent"
       },

--- a/packages/fmo-onboarding/default.nix
+++ b/packages/fmo-onboarding/default.nix
@@ -106,7 +106,7 @@ writeShellApplication {
       [yY][eE][sS] | [yY])
         cat $IP_FILE > /var/lib/fogdata/ip-address
         cat $HOSTNAME_FILE > /var/lib/fogdata/hostname
-        /run/current-system/sw/bin/onboarding-agent  --config /var/lib/fogdata/config.yaml --log-file /var/lib/fogdata/onboarding-agent.log
+        /run/current-system/sw/bin/onboarding-agent  --config /var/lib/fogdata/config.yaml --log-file /var/lib/fogdata/onboarding-agent.log --encrypt-secrets
       ;;
       *)
       ;;


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

Add `--encrypt-secrets` flag to onboarding-agent, to encrypt the secrets sent via NATS during registration with a one-time-use key.

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [x] Summary of the proposed changes in the PR description
- [x] More detailed description in the commit message(s)
- [x] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [ ] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Laptop`x86_64`
- [ ] Author has run `nix flake check` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf-fmo-laptop/actions)
- [x] Author has added reviewers and removed PR draft status
- [x] Change requires full re-installation
- [ ] Change can be updated with `nixos-rebuild ... switch`

<!-- Additional description of omitted [ ] items if not obvious. -->

## Instructions for Testing

- [x] List all targets that this applies to:
  - [x] x86_64
- [x] Is this a new feature
  - [ ] List the test steps to verify:
    1. Assuming that the test is done in the DEV environment, independently of which tenant
    2. Perform provisioning and registration fully
    3. After success, `cd` into the identity certificates' folder
    4. Get the device ID either by `cat`-ing the `identity.json` file, or by reading the logs 
    5. Run the following command to get the registration result for the device
        ```sh
        nats \
          -s nats://nats.dev.airoplatform.com:4222 \
          --tlscert identity.crt \
          --tlskey identity.key \
          --tlsca identity_ca.crt \
          stream view DEVICE_RESULTS --subject device_results.<device ID>.register --since 1m
        ```
    6. In the given result, find the `utmClientSecret` JSON key and base64 decode its value. The result should begin with
        ```sh
        age-encryption.org/v1
        -> X25519 ...
        ....
        ```
- [ ] If it is an improvement how does it impact existing functionality?
