### PR TITLE
dell: Add the other dell target

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -313,11 +313,11 @@
         "wireguard-gui": "wireguard-gui"
       },
       "locked": {
-        "lastModified": 1743623243,
-        "narHash": "sha256-FmnVZZK89g3CAE8JdfNpxJ3v0Mqx1OL5Yd5yMYuFr0M=",
+        "lastModified": 1743765360,
+        "narHash": "sha256-9Ix41es7fuSLA2fF2wWVfkxFZbtv/Qj+Qf6CepsKA4A=",
         "owner": "tiiuae",
         "repo": "ghaf",
-        "rev": "b7cd260220085c1fd8f1c5f3f0c8c67092f18cdb",
+        "rev": "10f75518dac9df738b34feeddc0fecd7eb5f7f97",
         "type": "github"
       },
       "original": {
@@ -786,11 +786,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743589519,
-        "narHash": "sha256-iBzr7Zb11nQxwX90bO1+Bm1MGlhMSmu4ixgnQFB+j4E=",
+        "lastModified": 1743748085,
+        "narHash": "sha256-uhjnlaVTWo5iD3LXics1rp9gaKgDRQj6660+gbUU3cE=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "18bed671738e36c5504e188aadc18b7e2a6e408f",
+        "rev": "815e4121d6a5d504c0f96e5be2dd7f871e4fd99d",
         "type": "github"
       },
       "original": {

--- a/modules/hardware/flake-module.nix
+++ b/modules/hardware/flake-module.nix
@@ -14,8 +14,13 @@
       ./resources/alienware-m18-r2.nix
       ./definition/external-usb.nix
     ];
-    hardware-dell-latitude-7330.imports = [
-      inputs.ghaf.nixosModules.hardware-dell-latitude-7330
+    hardware-dell-latitude-7330-71.imports = [
+      inputs.ghaf.nixosModules.hardware-dell-latitude-7330-71
+      ./resources/dell-latitude-7330.nix
+      ./definition/external-usb.nix
+    ];
+    hardware-dell-latitude-7330-72.imports = [
+      inputs.ghaf.nixosModules.hardware-dell-latitude-7330-72
       ./resources/dell-latitude-7330.nix
       ./definition/external-usb.nix
     ];

--- a/targets/flake-module.nix
+++ b/targets/flake-module.nix
@@ -31,8 +31,18 @@ let
         fmo.personalize.debug.enable = true;
       }
     ])
-    (laptop-configuration "fmo-dell-7330-debug" [
-      nixMods.hardware-dell-latitude-7330
+    # based on the wifi PCI address 71:00.0
+    (laptop-configuration "fmo-dell-7330-71-debug" [
+      nixMods.hardware-dell-latitude-7330-71
+      nixMods.fmo-profile
+      {
+        ghaf.profiles.debug.enable = true;
+        fmo.personalize.debug.enable = true;
+      }
+    ])
+    # based on the wifi PCI address 72:00.0
+    (laptop-configuration "fmo-dell-7330-72-debug" [
+      nixMods.hardware-dell-latitude-7330-72
       nixMods.fmo-profile
       {
         ghaf.profiles.debug.enable = true;


### PR DESCRIPTION
<!--
    Copyright 2023 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of changes

Add support for the 7330 with the wifi on bus 71. now both the known skus are supported.

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

## Checklist for things done

<!-- Please check, [X], to all that applies. Leave [ ] if an item does not apply but you have considered the check list item. Note that all of these are not hard requirements. They serve information to reviewers. When you fill the checklist, you indicate to reviewers you appreciate their work. -->

- [ ] Summary of the proposed changes in the PR description
- [ ] More detailed description in the commit message(s)
- [ ] Commits are squashed into relevant entities - avoid a lot of minimal dev time commits in the PR
- [ ] PR linked to architecture documentation and requirement(s) (ticket id)
- [ ] Test procedure described (or includes tests). Select one or more:
  - [ ] Tested on Laptop`x86_64`
- [ ] Author has run `nix flake check` and it passes
- [ ] All automatic Github Action checks pass - see [actions](https://github.com/tiiuae/ghaf-fmo-laptop/actions)
- [ ] Author has added reviewers and removed PR draft status
- [ ] Change requires full re-installation
- [ ] Change can be updated with `nixos-rebuild ... switch`

<!-- Additional description of omitted [ ] items if not obvious. -->

## Instructions for Testing

- [ ] List all targets that this applies to:
  - [ ] x86_64
- [ ] Is this a new feature
  - [ ] List the test steps to verify:
- [ ] If it is an improvement how does it impact existing functionality?
