### PR TITLE
packages(fmo-onboarding): set device alias

### DIFF
--- a/packages/fmo-onboarding/default.nix
+++ b/packages/fmo-onboarding/default.nix
@@ -30,6 +30,8 @@ writeShellApplication {
       IP_FILE=/var/common/ip-address
       HOSTNAME_FILE=/var/common/hostname
 
+      CONFIG_FILE=/var/lib/fogdata/config.yaml
+
       set_hostname(){
         # Read hostname from user
         read -e -r -p "Enter mDNS hostname: " HOSTNAME
@@ -53,6 +55,14 @@ writeShellApplication {
             echo "Invalid IP address: $IP"
           fi
         done
+      }
+
+      set_alias() {
+        # Read alias from user
+        read -r -p "Enter the alias for the device: " alias
+
+        # Update the alias in the config file
+        sed -i -e "s/Alias: .*/Alias: \"$alias\"/" "$CONFIG_FILE"
       }
 
       # Set mDNS hostname
@@ -95,13 +105,25 @@ writeShellApplication {
         set_ip
       fi
 
+      # Set device alias
+      echo ""
+      read -r -p "Do you want to set an alias for this device [y/N]? " response
+      case "$response" in
+      [yY][eE][sS] | [yY])
+        set_alias
+        ;;
+      *)
+        echo "No alias set."
+        ;;
+      esac
+
       echo ""
       read -r -p 'Do you want to start the onboarding agent? [y/N] ' response
       case "$response" in
       [yY][eE][sS] | [yY])
         cat $IP_FILE > /var/lib/fogdata/ip-address
         cat $HOSTNAME_FILE > /var/lib/fogdata/hostname
-        /run/current-system/sw/bin/onboarding-agent  --config /var/lib/fogdata/config.yaml --log-file /var/lib/fogdata/onboarding-agent.log --encrypt-secrets
+        /run/current-system/sw/bin/onboarding-agent  --config $CONFIG_FILE --log-file /var/lib/fogdata/onboarding-agent.log --encrypt-secrets
       ;;
       *)
       ;;


### PR DESCRIPTION
<!--
    Copyright 2022-2025 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

Allow user to set a device alias if it chooses to do so.

### Type of Change
- [ ] New Feature
- [X] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [X] Clear summary in PR description
- [X] Detailed and meaningful commit message(s)
- [X] Commits are logically organized and squashed if appropriate
- [X] [Contribution guidelines](https://github.com/tiiuae/ghaf-fmo-laptop/blob/main/CONTRIBUTING.md) followed
- [ ] Documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `nix flake check` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf-fmo-laptop/actions)
- [X] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [X] Lenovo X1 `x86_64`
- [X] Dell Latitude `x86_64`
- [X] Alienware `x86_64`

### Installation Method
- [X] Requires full re-installation (`just build ...installer`)
- [ ] Can be updated with `just rebuild ...`
- [ ] Other: 

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1. Run the installation as usual
2. Set an alias when asked
    - Prefer `kebab-case` notation for consistency with the other devices
3. After registration check that the previously set alias appears in
    - the UI
    - the `/var/lib/fogdata/onboarding-agent.log` file
    - the `/var/lib/fogdata/certs/device_id.json` file
