### PR TITLE
Network: Add MTU settings

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -313,11 +313,11 @@
         "wireguard-gui": "wireguard-gui"
       },
       "locked": {
-        "lastModified": 1744122993,
-        "narHash": "sha256-aum0TwPKGoRKkE/fHLcrIHUzBFIccQkZM7A1yn803A0=",
+        "lastModified": 1744188178,
+        "narHash": "sha256-qx0DQXrKPaGivT0R6SR5H0yHTWq5j+VAztEX/tyfrmA=",
         "owner": "tiiuae",
         "repo": "ghaf",
-        "rev": "865b53c3b5ffd6693a6f8dc93444a8383a977f88",
+        "rev": "527ecad08da86c26ffcec2d6553985458bd3b507",
         "type": "github"
       },
       "original": {

--- a/modules/microvm/guivm.nix
+++ b/modules/microvm/guivm.nix
@@ -35,7 +35,7 @@ let
     ];
   };
 
-  nvidia.enable = any (d: d.vendorId == "10de") config.ghaf.hardware.definition.gpu.pciDevices;
+  nvidia.enable = any (d: d.vendorId == "10de") config.ghaf.common.hardware.gpus;
 in
 {
   config = {

--- a/modules/microvm/netvm.nix
+++ b/modules/microvm/netvm.nix
@@ -6,7 +6,7 @@
 }:
 let
   inherit (config.ghaf.networking) hosts;
-  externalNics = map (d: d.name) config.ghaf.hardware.definition.network.pciDevices;
+  externalNics = map (d: d.name) config.ghaf.common.hardware.nics;
 in
 {
   imports = [
@@ -31,6 +31,7 @@ in
       fmo-firewall = {
         enable = true;
         inherit externalNics;
+        mtu = 1372;
         configuration = [
           {
             dip = hosts.docker-vm.ipv4;

--- a/modules/profile/fmo.nix
+++ b/modules/profile/fmo.nix
@@ -10,14 +10,12 @@
 {
   imports = [
     # Ghaf imports
-    inputs.ghaf.nixosModules.microvm
     inputs.ghaf.nixosModules.disko-debug-partition
-    inputs.ghaf.nixosModules.profiles
-    inputs.ghaf.nixosModules.profiles-laptop
+    inputs.ghaf.nixosModules.profiles-workstation
     inputs.ghaf.nixosModules.reference-appvms
-    inputs.ghaf.nixosModules.reference-profiles
     inputs.ghaf.nixosModules.reference-programs
     inputs.ghaf.nixosModules.reference-services
+    inputs.ghaf.nixosModules.reference-desktop
 
     # FMO imports
     inputs.self.nixosModules.host


### PR DESCRIPTION
<!--
    Copyright 2022-2025 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

Add custom MTU setting to external interfaces, and adjust imports to ghaf update.

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change
- [x] New Feature
- [ ] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [ ] Clear summary in PR description
- [ ] Detailed and meaningful commit message(s)
- [ ] Commits are logically organized and squashed if appropriate
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf-fmo-laptop/blob/main/CONTRIBUTING.md) followed
- [ ] Documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `nix flake check` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf-fmo-laptop/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Lenovo X1 `x86_64`
- [ ] Dell Latitude `x86_64`
- [ ] Alienware `x86_64`

### Installation Method
- [ ] Requires full re-installation (`just build ...installer`)
- [ ] Can be updated with `just rebuild ...`
- [ ] Other: 

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1. ...
