### PR TITLE
fix(portforwarding): allow all external interfaces

### DIFF
--- a/modules/fmo/fmo-firewall/default.nix
+++ b/modules/fmo/fmo-firewall/default.nix
@@ -13,35 +13,26 @@ let
     mkEnableOption
     mkOption
     types
-    optionalAttrs
-    concatStringsSep
+    optionalString
     concatMapStringsSep
     ;
 
   mkFirewallRules =
     {
-      interface,
       dip,
       sport,
       dport,
       proto,
     }:
     ''
-      iptables -t nat -A PREROUTING -i ${interface} -p ${proto} --dport ${sport} -j DNAT --to-destination ${dip}:${dport}
-      iptables -t nat -A POSTROUTING -o ${interface} -p ${proto} --dport ${sport} -j MASQUERADE
+      /run/current-system/sw/sbin/iptables -t nat -A PREROUTING -i "$IFACE" -p ${proto} --dport ${sport} -j DNAT --to-destination ${dip}:${dport}
+      /run/current-system/sw/sbin/iptables -t nat -A POSTROUTING -o "$IFACE" -p ${proto} --dport ${sport} -j MASQUERADE
     '';
 
 in
 {
   options.services.fmo-firewall = {
     enable = mkEnableOption "fmo-firewall";
-
-    externalNics = mkOption {
-      type = types.listOf types.str;
-      description = ''
-        List of external network interfaces with port forwarding rules.
-      '';
-    };
 
     mtu = mkOption {
       type = types.nullOr types.int;
@@ -69,36 +60,44 @@ in
 
     networking.firewall = {
       enable = true;
-      extraCommands = ''
-        ${concatMapStringsSep "\n" (
-          rule:
-          (concatMapStringsSep "\n" (
-            nic:
+    };
+
+    # Set MTU for external USB network devices
+    services.udev.extraRules = optionalString (cfg.mtu != null) ''
+      ACTION=="add", SUBSYSTEM=="net", KERNEL=="usb*", ATTR{mtu}="${toString cfg.mtu}"
+    '';
+
+    # Set MTU and port forwarding rules for external network interfaces
+    environment.etc."NetworkManager/dispatcher.d/99-fmo-rules" = {
+      text = ''
+        #!/bin/sh
+        IFACE="$1"
+        STATUS="$2"
+
+        add_rules(){
+          ${concatMapStringsSep "\n" (
+            rule:
             mkFirewallRules {
-              interface = nic;
               inherit (rule) dip;
               inherit (rule) sport;
               inherit (rule) dport;
               inherit (rule) proto;
             }
-          ) cfg.externalNics)
-        ) cfg.configuration}
-      '';
-    };
+          ) cfg.configuration}
+        }
 
-    # Set MTU
-    environment.etc."NetworkManager/dispatcher.d/99-mtu" = optionalAttrs (cfg.mtu != null) {
-      text = ''
-        #!/bin/sh
-        IFACE="$1"
-        STATUS="$2"
+        # Exclude loopback interface
+        if [ "$IFACE" == "lo" ]; then
+          exit 0
+        fi
+
         case "$STATUS" in
           up)
-            for iface in ${concatStringsSep " " cfg.externalNics}; do
-              if [[ "$IFACE" == "$iface" ]]; then
-                ip link set dev "$IFACE" mtu ${toString cfg.mtu}
-              fi
-            done
+            # Add port forwarding rules
+            add_rules
+
+            # Set MTU for the interface
+            ${optionalString (cfg.mtu != null) ''ip link set dev "$IFACE" mtu ${toString cfg.mtu}''}
           ;;
         esac
       '';

--- a/modules/microvm/netvm.nix
+++ b/modules/microvm/netvm.nix
@@ -6,7 +6,6 @@
 }:
 let
   inherit (config.ghaf.networking) hosts;
-  externalNics = map (d: d.name) config.ghaf.common.hardware.nics;
 in
 {
   imports = [
@@ -30,7 +29,6 @@ in
 
       fmo-firewall = {
         enable = true;
-        inherit externalNics;
         mtu = 1372;
         configuration = [
           {


### PR DESCRIPTION
<!--
    Copyright 2022-2025 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes
Change portforwarding rules for all external interfaces. Needed to allow any random external usb dongle.

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [ ] Clear summary in PR description
- [ ] Detailed and meaningful commit message(s)
- [ ] Commits are logically organized and squashed if appropriate
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf-fmo-laptop/blob/main/CONTRIBUTING.md) followed
- [ ] Documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `nix flake check` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf-fmo-laptop/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Lenovo X1 `x86_64`
- [ ] Dell Latitude `x86_64`
- [ ] Alienware `x86_64`

### Installation Method
- [ ] Requires full re-installation (`just build ...installer`)
- [ ] Can be updated with `just rebuild ...`
- [ ] Other: 

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1. ...
