### PR TITLE
gen12: Add the Lenovo x1 gen 12 laptop

### DIFF
--- a/modules/hardware/flake-module.nix
+++ b/modules/hardware/flake-module.nix
@@ -3,15 +3,15 @@
 { inputs, ... }:
 {
   flake.nixosModules = {
+    hardware-alienware-m18-r2.imports = [
+      inputs.ghaf.nixosModules.hardware-alienware-m18-r2
+      ./resources/alienware-m18-r2.nix
+      ./definition/external-usb.nix
+    ];
     hardware-dell-latitude-7230.imports = [
       inputs.ghaf.nixosModules.hardware-dell-latitude-7230
       ./resources/dell-latitude-7230.nix
       ./definition/dell-latitude-7230.nix
-      ./definition/external-usb.nix
-    ];
-    hardware-alienware-m18-r2.imports = [
-      inputs.ghaf.nixosModules.hardware-alienware-m18-r2
-      ./resources/alienware-m18-r2.nix
       ./definition/external-usb.nix
     ];
     hardware-dell-latitude-7330-71.imports = [
@@ -24,16 +24,21 @@
       ./resources/dell-latitude-7330.nix
       ./definition/external-usb.nix
     ];
-    hardware-lenovo-x1-carbon-gen11.imports = [
-      inputs.ghaf.nixosModules.hardware-lenovo-x1-carbon-gen11
-      ./resources/lenovo-x1-carbon-gen11.nix
-      ./definition/external-usb.nix
-    ];
     hardware-demo-tower-mk1.imports = [
       inputs.ghaf.nixosModules.hardware-demo-tower-mk1
       ./resources/demo-tower-mk1.nix
       # TODO: fix this upstream to support the usb kbd also
       #./definition/external-usb.nix
+    ];
+    hardware-lenovo-x1-carbon-gen11.imports = [
+      inputs.ghaf.nixosModules.hardware-lenovo-x1-carbon-gen11
+      ./resources/lenovo-x1-carbon-gen11.nix
+      ./definition/external-usb.nix
+    ];
+    hardware-lenovo-x1-carbon-gen12.imports = [
+      inputs.ghaf.nixosModules.hardware-lenovo-x1-carbon-gen12
+      ./resources/lenovo-x1-carbon-gen12.nix
+      ./definition/external-usb.nix
     ];
   };
 }

--- a/modules/hardware/resources/lenovo-x1-carbon-gen12.nix
+++ b/modules/hardware/resources/lenovo-x1-carbon-gen12.nix
@@ -4,15 +4,16 @@
 # This file specifies resource usage across Ghaf, as different
 # hardware has different capabilities.
 #
-# Lenovo X1 gen11 (Intel(R) Core(TM) i7-1355U)
-#    RAM:                  32 GB
-#    Cache:                12 MB
-#    Total Cores           10
-#    Performance-cores     2
-#    Efficient-cores       8
-#    Total Threads         12
-#    Processor Base Power  15 W
-#    Maximum Turbo Power   55 W
+# Lenovo X1 gen12 (Intel(R) Core(TM) ultra 7 155U)
+#    RAM:                       32 GB
+#    Cache:                     12 MB
+#    Total Cores                12
+#    Performance-cores           2
+#    Efficient-cores             8
+#    Low Power Efficient-cores   2
+#    Total Threads              14
+#    Processor Base Power       15 W
+#    Maximum Turbo Power        57 W
 #
 # Resource allocation:
 #    Net VM:     1 vcpu    512 MB

--- a/targets/flake-module.nix
+++ b/targets/flake-module.nix
@@ -57,6 +57,14 @@ let
         fmo.personalize.debug.enable = true;
       }
     ])
+    (laptop-configuration "fmo-lenovo-x1-gen12-debug" [
+      nixMods.hardware-lenovo-x1-carbon-gen12
+      nixMods.fmo-profile
+      {
+        ghaf.profiles.debug.enable = true;
+        fmo.personalize.debug.enable = true;
+      }
+    ])
     (laptop-configuration "fmo-demo-tower-mk1-debug" [
       nixMods.hardware-demo-tower-mk1
       nixMods.fmo-profile


### PR DESCRIPTION
<!--
    Copyright 2022-2025 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

Extend support for FMO to include support for the Lenovo x1 carbon gen12 devices.

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [ ] Clear summary in PR description
- [ ] Detailed and meaningful commit message(s)
- [ ] Commits are logically organized and squashed if appropriate
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf-fmo-laptop/blob/main/CONTRIBUTING.md) followed
- [ ] Documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `nix flake check` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf-fmo-laptop/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Lenovo X1 `x86_64`
- [ ] Dell Latitude `x86_64`
- [ ] Alienware `x86_64`

### Installation Method
- [ ] Requires full re-installation (`just build ...installer`)
- [ ] Can be updated with `just rebuild ...`
- [ ] Other: 

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1. ...
