### PR TITLE
chrome: Add flags to enable media decode offload to GPU

### DIFF
--- a/modules/microvm/guivm.nix
+++ b/modules/microvm/guivm.nix
@@ -29,9 +29,10 @@ let
       # Hardware video encoding on Chrome on Linux.
       # See chrome://gpu to verify.
       # Enable H.265 video codec support.
-      "--enable-features=UseOzonePlatform,VaapiVideoDecoder,VaapiVideoEncoder,WebRtcAllowH265Receive,VaapiIgnoreDriverChecks"
+      "--enable-features=AcceleratedVideoDecodeLinuxGL,UseOzonePlatform,VaapiVideoDecoder,VaapiVideoEncoder,WebRtcAllowH265Receive,VaapiIgnoreDriverChecks"
       "--ozone-platform=wayland"
       "--force-fieldtrials=WebRTC-Video-H26xPacketBuffer/Enabled"
+      "--enable-zero-copy"
     ];
   };
 


### PR DESCRIPTION
<!--
    Copyright 2022-2025 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes
Enabling AcceleratedVideoDecodeLinuxGL feature will result in using hardware acceleration by invoking
Intel media decoder for browser based rendering and decoding. Also zero copy may improve performance.

### Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [x] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf-fmo-laptop/blob/main/CONTRIBUTING.md) followed
- [ ] Documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [x] Author has run `nix flake check` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf-fmo-laptop/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [x] Lenovo X1 `x86_64`
- [x] Dell Latitude `x86_64`
- [x] Alienware `x86_64`

### Installation Method
- [ ] Requires full re-installation (`just build ...installer`)
- [x] Can be updated with `just rebuild ...`
- [ ] Other: 

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1. Run video playback in browser, like youtube.
2. Run below command and check `Video` engine load, if getting increased during `playback` then media decoding is getting offloaded to `gpu`.
    ```
    [ghaf@gui-vm:~]$ sudo intel_gpu_top
    ``` 
