### PR TITLE
dell: Unify Dell latitude 7330 configurations

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -312,11 +312,11 @@
         "wireguard-gui": "wireguard-gui"
       },
       "locked": {
-        "lastModified": 1748286715,
-        "narHash": "sha256-h1Y//c4ednsEeqp/TvH70rO5FFSIBboXgBzcHmh186g=",
+        "lastModified": 1748416517,
+        "narHash": "sha256-6iwJe5OYVhgY9Va7uWy/coxtuBmgOiwfX80reua5eec=",
         "owner": "tiiuae",
         "repo": "ghaf",
-        "rev": "38673803102ce8299cb9b2cbd94d711a69d848df",
+        "rev": "cdfeb54072fb59c34685c5ce01c005216710c594",
         "type": "github"
       },
       "original": {
@@ -556,17 +556,16 @@
         "spectrum": "spectrum"
       },
       "locked": {
-        "lastModified": 1747835143,
-        "narHash": "sha256-QavJX/oommtEBCWN6Qlcl6JhCAc8Sy+KlOImc0yVCXk=",
+        "lastModified": 1748260747,
+        "narHash": "sha256-V3ONd70wm55JxcUa1rE0JU3zD+Cz7KK/iSVhRD7lq68=",
         "owner": "astro",
         "repo": "microvm.nix",
-        "rev": "1d261ced5ea10b000d30932d5ec41a68063b9e8e",
+        "rev": "b6c5dfc2a1c7614c94fd2c5d2e8578fd52396f3b",
         "type": "github"
       },
       "original": {
         "owner": "astro",
         "repo": "microvm.nix",
-        "rev": "1d261ced5ea10b000d30932d5ec41a68063b9e8e",
         "type": "github"
       }
     },

--- a/modules/hardware/flake-module.nix
+++ b/modules/hardware/flake-module.nix
@@ -14,13 +14,8 @@
       ./definition/dell-latitude-7230.nix
       ./definition/external-usb.nix
     ];
-    hardware-dell-latitude-7330-71.imports = [
-      inputs.ghaf.nixosModules.hardware-dell-latitude-7330-71
-      ./resources/dell-latitude-7330.nix
-      ./definition/external-usb.nix
-    ];
-    hardware-dell-latitude-7330-72.imports = [
-      inputs.ghaf.nixosModules.hardware-dell-latitude-7330-72
+    hardware-dell-latitude-7330.imports = [
+      inputs.ghaf.nixosModules.hardware-dell-latitude-7330
       ./resources/dell-latitude-7330.nix
       ./definition/external-usb.nix
     ];

--- a/targets/flake-module.nix
+++ b/targets/flake-module.nix
@@ -47,18 +47,8 @@ let
         fmo.personalize.debug.enable = true;
       }
     ])
-    # based on the wifi PCI address 71:00.0
-    (laptop-configuration "fmo-dell-7330-71-debug" [
-      nixMods.hardware-dell-latitude-7330-71
-      nixMods.fmo-profile
-      {
-        ghaf.profiles.debug.enable = true;
-        fmo.personalize.debug.enable = true;
-      }
-    ])
-    # based on the wifi PCI address 72:00.0
-    (laptop-configuration "fmo-dell-7330-72-debug" [
-      nixMods.hardware-dell-latitude-7330-72
+    (laptop-configuration "fmo-dell-7330-debug" [
+      nixMods.hardware-dell-latitude-7330
       nixMods.fmo-profile
       {
         ghaf.profiles.debug.enable = true;


### PR DESCRIPTION
<!--
    Copyright 2022-2025 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

With microvm support, we now have the ability to dynamically detect PCI IDs for device passthrough.
This allows the system to retrieve PCI IDs at runtime, eliminating the need to maintain different configurations for the same platform. Details in https://github.com/tiiuae/ghaf/pull/1220
    
Also bump: latest ghaf and microvm packages


### Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [ ] Clear summary in PR description
- [ ] Detailed and meaningful commit message(s)
- [ ] Commits are logically organized and squashed if appropriate
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf-fmo-laptop/blob/main/CONTRIBUTING.md) followed
- [ ] Documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `nix flake check` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf-fmo-laptop/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Lenovo X1 `x86_64`
- [ ] Dell Latitude `x86_64`
- [ ] Alienware `x86_64`

### Installation Method
- [ ] Requires full re-installation (`just build ...installer`)
- [ ] Can be updated with `just rebuild ...`
- [ ] Other: 

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1. ...
