### PR TITLE
Google-chrome: treat fmo-ui url as secure

### DIFF
--- a/modules/microvm/guivm.nix
+++ b/modules/microvm/guivm.nix
@@ -31,6 +31,9 @@ let
 
   google-chrome = (rmDesktopEntry pkgs.google-chrome).override {
     commandLineArgs = [
+      # Enable secure browser apis for the fmo-ui
+      "--unsafely-treat-insecure-origin-as-secure=\"http://docker-vm:3000\""
+
       # Hardware video encoding on Chrome on Linux.
       # See chrome://gpu to verify.
       # Enable H.265 video codec support.


### PR DESCRIPTION
<!--
    Copyright 2022-2025 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

Adds a flag for google-chrome to treat FMO UI url as a secure origin to enable WebRTC and Video Codec APIs.

### Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [x] Improvement / Refactor

## Checklist

- [ ] Clear summary in PR description
- [ ] Detailed and meaningful commit message(s)
- [ ] Commits are logically organized and squashed if appropriate
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf-fmo-laptop/blob/main/CONTRIBUTING.md) followed
- [ ] Documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [ ] Author has run `nix flake check` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf-fmo-laptop/actions)
- [ ] Author has added reviewers and removed PR draft status

## Testing Instructions

### Applicable Targets
- [x] Lenovo X1 `x86_64`
- [x] Dell Latitude `x86_64`
- [x] Alienware `x86_64`

### Installation Method
- [ ] Requires full re-installation (`just build ...installer`)
- [ ] Can be updated with `just rebuild ...`
- [ ] Other: 

### Test Steps To Verify:
1. WebRTC video transport and NATS AV1 codec should work without additional changes to the browser settings
