### PR TITLE
feature(onboarding): add ID in identity DNS names

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -664,11 +664,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1750662569,
-        "narHash": "sha256-dipmdyCH+fWodm9JYBE18i7yuiU1WY9l8nLpkrjZlcU=",
+        "lastModified": 1750765302,
+        "narHash": "sha256-PM9asW4BWjHECSIYS/4g5WI+rXoXxnFKpR/pydnCt4Y=",
         "ref": "refs/heads/main",
-        "rev": "4f322b3fbbe8951feb0771e3ec4af6380c6f5c8d",
-        "revCount": 415,
+        "rev": "e92016e3805e6393e5c7c22b81cc19ac574c3239",
+        "revCount": 417,
         "type": "git",
         "url": "ssh://git@github.com/tiiuae/onboarding-agent"
       },


### PR DESCRIPTION
<!--
    Copyright 2022-2025 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

Add `deviceID` and `deviceID.local.` DNS names to identity (backbone) NATS certificates.

More info: https://github.com/tiiuae/onboarding-agent/pull/54

### Type of Change
- [x] New Feature
- [ ] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf-fmo-laptop/blob/main/CONTRIBUTING.md) followed
- [ ] Documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [x] Author has run `nix flake check` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf-fmo-laptop/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [x] Lenovo X1 `x86_64`
- [x] Dell Latitude `x86_64`
- [x] Alienware `x86_64`

### Installation Method
- [x] Requires full re-installation (`just build ...installer`)
- [ ] Can be updated with `just rebuild ...`
- [ ] Other: 

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1. @thurrox to test an image created from this PR
