### PR TITLE
vhotplug: Support for the GPS device

### DIFF
--- a/modules/hardware/usb/vhotplug-rules.nix
+++ b/modules/hardware/usb/vhotplug-rules.nix
@@ -13,6 +13,11 @@
             class = 11;
             description = "Chip/SmartCard (e.g. YubiKey)";
           }
+          {
+            vendorId = "0403";
+            productId = "6015";
+            description = "FTDI FT231X USB UART to access GPS device";
+          }
         ];
       }
     ];


### PR DESCRIPTION
<!--
    Copyright 2022-2025 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes
Added FTDI FT231X USB UART interface device to facilitate access to the GPS device for the docker-vm.

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [x] Improvement / Refactor

## Related Issues / Tickets
Fixes SSRCSP-6773

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf-fmo-laptop/blob/main/CONTRIBUTING.md) followed
- [ ] Documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [x] Author has run `nix flake check` and it passes
- [x] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf-fmo-laptop/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [x] Lenovo X1 `x86_64`
- [x] Dell Latitude `x86_64`
- [x] Alienware `x86_64`

### Installation Method
- [ ] Requires full re-installation (`just build ...installer`)
- [x] Can be updated with `just rebuild ...`
- [ ] Other: 

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1.  Attach FTDI FT231X USB UART device and GPS functionality should work in `docker-vm`
2.  Tested in `docker-vm` using
    ```
    screen /dev/ttyUSB0 115200
    ```
