### PR TITLE
gui-vm: Enable video acceleration info for google-chrome on Nvidia GPU

### DIFF
--- a/modules/microvm/guivm.nix
+++ b/modules/microvm/guivm.nix
@@ -28,18 +28,20 @@ let
         buildCommand = old.buildCommand + "rm -rf \"$out/share/applications\"";
       }
     );
+  nvidiaEnabled = config.ghaf.graphics.nvidia-setup.enable;
+  chromeExtraArgs =
+    optionalString (!nvidiaEnabled) ",UseOzonePlatform"
+    + optionalString nvidiaEnabled ",VaapiOnNvidiaGPUs";
 
   google-chrome = (rmDesktopEntry pkgs.google-chrome).override {
     commandLineArgs = [
       # Hardware video encoding on Chrome on Linux.
       # See chrome://gpu to verify.
       # Enable H.265 video codec support.
-      "--enable-features=AcceleratedVideoDecodeLinuxGL,VaapiVideoDecoder,VaapiVideoEncoder,WebRtcAllowH265Receive,VaapiIgnoreDriverChecks,WaylandLinuxDrmSyncobj${
-        optionalString (!config.ghaf.graphics.nvidia-setup.enable) ",UseOzonePlatform"
-      }"
+      "--enable-features=AcceleratedVideoDecodeLinuxGL,VaapiVideoDecoder,VaapiVideoEncoder,WebRtcAllowH265Receive,VaapiIgnoreDriverChecks,WaylandLinuxDrmSyncobj${chromeExtraArgs}"
       "--force-fieldtrials=WebRTC-Video-H26xPacketBuffer/Enabled"
       "--enable-zero-copy"
-    ] ++ optionals (!config.ghaf.graphics.nvidia-setup.enable) [ "--ozone-platform=wayland" ];
+    ] ++ optionals (!nvidiaEnabled) [ "--ozone-platform=wayland" ];
   };
 
 in
@@ -53,7 +55,7 @@ in
 
       #Primary drivers for the integrated GPU should not be enabledd for prime case
       intel-setup = {
-        enable = !config.ghaf.graphics.nvidia-setup.enable;
+        enable = !nvidiaEnabled;
       };
     };
 


### PR DESCRIPTION
<!--
    Copyright 2022-2025 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes
Support has been added for Video Acceleration information when using hardware decoders in Google Chrome with an Nvidia GPU.

Without `VaapiOnNvidiaGPUs` flag, Google Chrome `Video Acceleration Information` is empty. 

### Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [x] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf-fmo-laptop/blob/main/CONTRIBUTING.md) followed
- [ ] Documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [x] Author has run `nix flake check` and it passes
- [x] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf-fmo-laptop/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [ ] Lenovo X1 `x86_64`
- [ ] Dell Latitude `x86_64`
- [x] Alienware `x86_64`

### Installation Method
- [ ] Requires full re-installation (`just build ...installer`)
- [x] Can be updated with `just rebuild ...`
- [ ] Other: 

### Test Steps To Verify:
1. Open `Google Chrome GPU` app and type `chrome://gpu` in URL, scroll to bottom to check

    ![image](https://github.com/user-attachments/assets/616055cb-b908-4392-ba2b-9326e1f0ba76)


**Note:** Without this PR changes, still hardware acceleration happening on GPU, however `Google Chrome` was not showing `Video Acceleration Information` support. 