### PR TITLE
fix(onboarding): HW proto file missing in config

### DIFF
--- a/modules/fmo/fmo-onboarding-agent/default.nix
+++ b/modules/fmo/fmo-onboarding-agent/default.nix
@@ -67,6 +67,12 @@ in
       type = types.path;
       default = "/var/lib/fogdata/onboarding-agent.log";
     };
+
+    hardware_config_file = mkOption {
+      description = "Path to the hardware definition proto file";
+      type = types.path;
+      default = "/var/lib/fogdata/hw_conf.proto";
+    };
   };
 
   config = mkIf cfg.enable {
@@ -102,6 +108,7 @@ in
               ConfigurationFile: "${cfg.config_path}/docker-compose.yml"
               ConfigurationTemplateFile: "${cfg.config_path}/docker-compose.mustache"
               NatsLeafConfigurationFile: "${cfg.certs_path}/leaf.conf"
+              HardwareConfigurationFile: "${cfg.hardware_config_file}"
             Identity:
               CaCertFile: "${cfg.certs_path}/identity_ca.crt"
               CertFile: "${cfg.certs_path}/identity.crt"


### PR DESCRIPTION
<!--
    Copyright 2022-2025 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->
HW device Protofile path missing in onboarding-agent configuration.

### Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Improvement / Refactor

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [ ] [Contribution guidelines](https://github.com/tiiuae/ghaf-fmo-laptop/blob/main/CONTRIBUTING.md) followed
- [x] Documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [x] Author has run `nix flake check` and it passes
- [ ] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf-fmo-laptop/actions)
- [ ] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [x] Lenovo X1 `x86_64`
- [x] Dell Latitude `x86_64`
- [x] Alienware `x86_64`

### Installation Method
- [ ] Requires full re-installation (`just build ...installer`)
- [x] Can be updated with `just rebuild ...`
- [ ] Other: 

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1. Onboard and verify that onboarding succeeds
