### PR TITLE
add avahi ntp service to net-vm

### DIFF
--- a/modules/microvm/netvm.nix
+++ b/modules/microvm/netvm.nix
@@ -65,6 +65,22 @@ in
         enable = true;
         nssmdns4 = true;
         reflector = true;
+        publish = {
+          enable = true;
+          domain = true;
+          addresses = true;
+        };
+        extraServiceFiles = {
+          ntp = ''
+            <service-group>
+              <name>NTP Server</name>
+              <service>
+                <type>_ntp._udp</type>
+                <port>123</port>
+              </service>
+            </service-group>
+          '';
+        };
       };
 
       fmo-firewall = {


### PR DESCRIPTION
<!--
    Copyright 2022-2025 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description of Changes

<!--
Summary of the proposed changes in the PR description in your own words. For dependency updates, please link to the changelog.
-->

### Type of Change
- [x] New Feature
- [ ] Bug Fix
- [ ] Improvement / Refactor

Enables resolving timesync server in fog-ghaf. Related PR: https://github.com/tiiuae/fog-ghaf/pull/64 

## Related Issues / Tickets

<!--
Link to GitHub issues or JIRA tickets (if any) that this PR addresses or is related to
-->

https://jira.tii.ae/browse/SSRCDP-11568

## Checklist

<!--
Please check [X] for all items that apply. Leave [ ] if an item does not apply, but you have considered it.
Note that none of these are strict requirements — they are intended to inform reviewers.
Completing this checklist shows that you value and respect their time and effort.
-->

- [x] Clear summary in PR description
- [x] Detailed and meaningful commit message(s)
- [x] Commits are logically organized and squashed if appropriate
- [x] [Contribution guidelines](https://github.com/tiiuae/ghaf-fmo-laptop/blob/main/CONTRIBUTING.md) followed
- [ ] Documentation updated with the commit - https://tiiuae.github.io/ghaf/
- [x] Author has run `nix flake check` and it passes
- [x] All automatic GitHub Action checks pass - see [actions](https://github.com/tiiuae/ghaf-fmo-laptop/actions)
- [x] Author has added reviewers and removed PR draft status

<!-- Additional description of omitted [ ] items if not obvious. -->

## Testing Instructions

### Applicable Targets
- [x] Lenovo X1 `x86_64`
- [ ] Dell Latitude `x86_64`
- [ ] Alienware `x86_64`

### Installation Method
- [ ] Requires full re-installation (`just build ...installer`)
- [x] Can be updated with `just rebuild ...`
- [ ] Other: 

### Test Steps To Verify:
<!--
Provide clear, simple step-by-step instructions to verify the functionality.
Please do not assume that readers know everything you currently know.
-->
1. Run `avahi-browse -r _ntp._udp` on another machine on the same network
2. You should see the hostname and ip address of the resolved service
